### PR TITLE
Add the ability to import main machine's CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ EXPOSE 8555/tcp
 VOLUME /root/.chia
 VOLUME /mnt/chia-plots/tmp
 VOLUME /mnt/chia-plots/final
+VOLUME /mnt/passed-ca
 
 ENV chia_dir="/opt/chia-blockchain"
 ENV chia_update_on_init="true"
@@ -29,6 +30,7 @@ ENV plots_final_dir="/mnt/chia-plots/final"
 ENV plots_options=""
 ENV prevent_sleep=""
 ENV plots_curl_target=""
+ENV CA_PROVIDED="false"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update

--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ Map volumes:
 - /root/.chia - blockchain, config and potentially keys (mnemonic.txt)
 - /mnt/chia-plots/final - plots on storage
 - /mnt/chia-plots/tmp - *fast* storage for plotting, add one per device
+- /mt/passed-ca - passed in CA, copied from your main node.
 
 Possible start values are
 - all
@@ -44,6 +45,7 @@ Other environment variables
 - prevent_sleep - (string) Default: "", Set to *caffeinate -i* on Mac OS to prevent sleep
 - plots_options - (string) Can be used to specify plots options like "--nobitfield"
 - plots_curl_target - (string) Target for curl, e.g. ftp://anonymous@farmer/plots
+- CA_PROVIDED -(string) true or false, if true we will check the /mnt/passed-ca directory for your ca keys to be imported.
 
 ## Scripts
 
@@ -105,7 +107,7 @@ docker run --name <container-name>  \
     -d gldecurtins/chia-docker:latest
 ```
 
-Full node startup on mainnet, use existing keys. E.g. store your words into /path/to/.chia/mnemonic.txt. 
+Full node startup on mainnet, use existing keys. E.g. store your words into /path/to/.chia/mnemonic.txt.
 ```
 docker run --name <container-name> \
     --volume /path/to/.chia:/root/.chia --volume /path/to/plots:/mnt/chia-plots/final \

--- a/scripts/container_entrypoint.sh
+++ b/scripts/container_entrypoint.sh
@@ -7,9 +7,19 @@ init_chia () {
 
     cd ${chia_dir}
     . ./activate
+
     chia init
+    #
+    #If the user is using us in multimachine mode we need his ca, he has passed it in we must import the ca into our config
+    #
+
+    if [[ "${CA_PROVIDED}" == "true" ]]; then
+        echo "CA has been provided, importing..."
+        chia init -c /mnt/passed-ca
+    fi
 
     sed -i 's/localhost/127.0.0.1/g' ~/.chia/mainnet/config/config.yaml
+
 }
 
 init_network () {
@@ -36,7 +46,8 @@ init_keys () {
         echo "To use your own keys pass them as a text file. Generating keys now."
         chia keys generate
     else
-        chia keys add -f ${keys}
+        echo "adding keys from mnemonic"
+        chia keys add -f "${keys}"
     fi
 }
 


### PR DESCRIPTION
When running the docker container on a plotter only machine we may want the ability to import the main machine's CA.  This pull request adds that functionality.

Example bash file of using the functionality:
```
#!/bin/bash
set +x

FAST_STORAGE=/home/snoby/
ICE_STORAGE=/home/snoby/
CONT_NAME=iotapi322/chia:may21
NAME=chia

# COPY OF YOUR INITIAL INSTALL ca directory
CA_DIR=/home/snoby/chia_ca

docker stop $NAME
docker rm $NAME

NAME=chia
docker run -it \
	--name="$NAME"   \
	-v "$FAST_STORAGE":/mnt/chia-plots/tmp   \
	-v "$ICE_STORAGE":/mnt/chia-plots/final   \
	-v "$CA_DIR":/mnt/passed-ca:ro              \
	-v `pwd`/mnemonic.txt:/tmp/mnemonic.txt:ro              \
	-v `pwd`/container_entrypoint.sh:/usr/local/bin/container_entrypoint.sh \
	-e keys="/tmp/mnemonic.txt"                   \
	-e CA_PROVIDED=true                      \
	-e chia_update_on_init=false             \
	-e plots_farmer_public_key="$FARM_KEY" \
        -e plots_pool_public_key="$POOL_KEY" \
	"${CONT_NAME}"
```